### PR TITLE
Try out two-stage generation, getting the JSON second.

### DIFF
--- a/question-generation/reflectia/src/taskpane/taskpane.js
+++ b/question-generation/reflectia/src/taskpane/taskpane.js
@@ -204,7 +204,7 @@ async function main() {
       // Create a card for each reflection returned
       for (let j = 0; j < reflections.length; j++) {
         const reflection = reflections[j];
-        const card = createCard(i, reflection.text_in_HTML_format);
+        const card = createCard(i, reflection.response_text);
         cardsFragment.appendChild(card);
       }
     }


### PR DESCRIPTION
I changed the text field name to try to discourage the model from just quoting the input text, which it was tending to do. Untested!

I'm hoping that the lower temperature for JSON generation will reduce the chance of generation failures. It would be even better to use the openai function calling mechanism; basically we'd force the model to call a function with the desired schema, and it'll generate JSON of the right format by construction.

TODO

- [ ] add tests!
- [ ] Switch to json schema, [example](https://chat.openai.com/share/946e443a-36d1-405a-9381-de280d136066), and force a call to a fictitious `show_reflections` (or similar) function.
